### PR TITLE
fix(#sfd2-701): run allure in ci

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 echo "run_id: $RUN_ID"
-npm run test:allure
+npm run test:ci
 
-#npm run report:publish
+npm run report:publish
 publish_exit_code=$?
 
 if [ $publish_exit_code -ne 0 ]; then

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "report:publish": "npm run report; ./bin/publish-tests.sh",
     "test:smoke": "cucumber-js --tags '@smoke'",
     "test": "cucumber-js --format progress",
-    "test:allure": "cucumber-js --format progress --format allure-cucumberjs/reporter && allure generate allure-results --clean -o allure-report && allure open allure-report"
+    "test:allure": "cucumber-js --format progress --format allure-cucumberjs/reporter && allure generate allure-results --clean -o allure-report && allure open allure-report",
+    "test:ci": "cucumber-js --format progress --format allure-cucumberjs/reporter && allure generate allure-results --clean -o allure-report"
   },
   "dependencies": {
     "@wdio/allure-reporter": "9.23.3",


### PR DESCRIPTION
This PR is an attempt to fix the command in the entrypoint so that allure can run in a CI environment and publish its report.

It duplicates existing command but does not attempt to open the report since you cannot do that in ci.