### PR TITLE
Group Dependabot updates by security and dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,69 @@
+---
 version: 2
-
 updates:
-  - package-ecosystem: "docker-compose"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-    open-pull-requests-limit: 5
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
+- package-ecosystem: docker-compose
+  directory: "/"
+  schedule:
+    interval: daily
+  commit-message:
+    prefix: chore
+  open-pull-requests-limit: 5
+  groups:
+    docker-security:
+      applies-to: security-updates
+      patterns:
+      - "*"
+    docker-non-security:
+      applies-to: version-updates
+      patterns:
+      - "*"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  commit-message:
+    prefix: chore
+  groups:
+    npm-security:
+      applies-to: security-updates
+      patterns:
+      - "*"
+    lint:
+      applies-to: version-updates
+      patterns:
+      - eslint
+      - eslint-*
+      - prettier
+    tools:
+      applies-to: version-updates
+      patterns:
+      - husky
+    types:
+      applies-to: version-updates
+      patterns:
+      - "@types/*"
+    npm-production:
+      applies-to: version-updates
+      dependency-type: production
+      patterns:
+      - "*"
+    npm-development:
+      applies-to: version-updates
+      dependency-type: development
+      patterns:
+      - "*"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+  groups:
+    github-actions-security:
+      applies-to: security-updates
+      patterns:
+      - "*"
+    github-actions-non-security:
+      applies-to: version-updates
+      patterns:
+      - "*"

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-exact=true
 ignore-scripts=true
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "prettier": "3.8.3"
       },
       "engines": {
-        "node": ">=22.13.1"
+        "node": ">=22.13.1",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "description": "",
   "engines": {
-    "node": ">=22.13.1"
+    "node": ">=22.13.1",
+    "npm": ">=11.10.0"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",


### PR DESCRIPTION
- Separate security updates from version updates for all ecosystems
- Group npm updates by production vs development dependencies
- Group docker-compose updates by security vs non-security
- Group github-actions updates by security vs non-security