### PR TITLE
Sfd2 991 fix certs

### DIFF
--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -32,17 +32,20 @@ Before(async function () {
     headless: true
   }
 
-  // Proxy for CDP - bypass for internal *.cdp-int.defra.cloud services
   if (process.env.CDP_PROXY === 'true') {
     launchOptions.proxy = {
-      server: 'http://localhost:3128',
-      bypass: '*.cdp-int.defra.cloud'
+      server: 'http://localhost:3128'
     }
+    launchOptions.args = [
+      '--ignore-certificate-errors',
+      '--disable-background-networking',
+      '--dns-prefetch-disable'
+    ]
   }
 
   this.browser = await chromium.launch(launchOptions)
 
-  this.context = await this.browser.newContext()
+  this.context = await this.browser.newContext({ ignoreHTTPSErrors: true })
   this.page = await this.context.newPage()
 })
 

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -3,8 +3,8 @@ import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import { faker } from '@faker-js/faker'
 
-const BASE_URL =
-  process.env.BASE_URL || 'https://fcp-sfd-frontend.test.cdp-int.defra.cloud'
+const ENVIRONMENT = process.env.ENVIRONMENT || 'test'
+const BASE_URL = `https://fcp-sfd-frontend.${ENVIRONMENT}.cdp-int.defra.cloud`
 
 Given(
   'I am on SignIn page and enter the credentials for {string}',


### PR DESCRIPTION
Match cdp-portal-journey-tests config: the CDP proxy does SSL
interception, so Chromium needs --ignore-certificate-errors to load
pages through it. Also adds ignoreHTTPSErrors on the browser context.

CDP injects BASE_URL as the environment root, conflicting with our
usage. Switch to ENVIRONMENT var (matching cdp-portal-journey-tests
pattern) to construct the full service URL.