### PR TITLE
Sfd2 991 fix cached session

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,11 +6,13 @@ echo "BASE_URL: $BASE_URL"
 
 # Network diagnostics
 echo "--- Network diagnostics ---"
-echo "Proxy check (localhost:3128):"
-curl -s -o /dev/null -w "HTTP %{http_code}" --proxy http://localhost:3128 "${BASE_URL:-https://fcp-sfd-frontend.test.cdp-int.defra.cloud}/" || echo "FAILED"
+AUTH_URL="https://your-account.cpdev.cui.defra.gov.uk/registration/journey/check-js/check-js-enabled"
+
+echo "Request 1 to auth URL via proxy (headers):"
+curl -s -o /dev/null -D - --proxy http://localhost:3128 --insecure "$AUTH_URL" | grep -i "x-cache\|age:\|x-squid\|via:\|http/"
 echo ""
-echo "Direct check (no proxy):"
-curl -s -o /dev/null -w "HTTP %{http_code}" "${BASE_URL:-https://fcp-sfd-frontend.test.cdp-int.defra.cloud}/" || echo "FAILED"
+echo "Request 2 to auth URL via proxy (headers - check for HIT):"
+curl -s -o /dev/null -D - --proxy http://localhost:3128 --insecure "$AUTH_URL" | grep -i "x-cache\|age:\|x-squid\|via:\|http/"
 echo ""
 echo "--- End diagnostics ---"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 echo "run_id: $RUN_ID"
 echo "CDP_PROXY: $CDP_PROXY"
-echo "BASE_URL: $BASE_URL"
+echo "TEST_SUITE_BASE_URL: $TEST_SUITE_BASE_URL"
 
 # Network diagnostics
 echo "--- Network diagnostics ---"

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -1,9 +1,10 @@
 // tests/helpers/helpers.js
 
-export const BASE_URL = process.env.BASE_URL
+const ENVIRONMENT = process.env.ENVIRONMENT || 'test'
+const TEST_SUITE_BASE_URL = `https://fcp-sfd-frontend.${ENVIRONMENT}.cdp-int.defra.cloud`
 
 export async function goToLandingPage(page) {
-  await page.goto(`${BASE_URL}/`)
+  await page.goto(`${TEST_SUITE_BASE_URL}/`)
   await page
     .locator('#main-content > div > div > a')
     .waitFor({ state: 'visible' })

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -7,7 +7,7 @@ import {
   loginAsAmendPermissionUser,
   loginAsViewPermissionUser,
   goToLandingPage,
-  BASE_URL
+  TEST_SUITE_BASE_URL
 } from '../helpers/helpers.js'
 
 Given(
@@ -389,7 +389,7 @@ When('I open another tab with the same session', async function () {
 When('I signOut on the first tab', async function () {
   await this.page1.bringToFront()
   await this.page1.locator("//a[normalize-space()='Sign out']").click()
-  await this.page1.waitForURL(`${BASE_URL}/signed-out**`)
+  await this.page1.waitForURL(`${TEST_SUITE_BASE_URL}/signed-out**`)
 })
 
 When('I switch to the second tab', async function () {
@@ -1547,7 +1547,7 @@ Given(
 )
 
 Then('Navigate to {string}', async function (baseurl) {
-  await this.page.goto(`${BASE_URL}${baseurl}`)
+  await this.page.goto(`${TEST_SUITE_BASE_URL}${baseurl}`)
 })
 
 Then(

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -345,6 +345,7 @@ When('I click signOut link on the {string} page', async function (signOutPage) {
       await this.page.locator("//a[normalize-space()='Sign out']").click()
       break
     case 'enteryourbusinessaddress':
+    case 'whatisyourbusinessemailaddress':
       await this.page
         .getByRole('link', { name: 'Business email address' })
         .click()
@@ -353,12 +354,6 @@ When('I click signOut link on the {string} page', async function (signOutPage) {
     case 'whatareyourbusinessphonemembers':
       await this.page
         .getByRole('link', { name: 'Change Business telephone numbers' })
-        .click()
-      await this.page.locator("//a[normalize-space()='Sign out']").click()
-      break
-    case 'whatisyourbusinessemailaddress':
-      await this.page
-        .getByRole('link', { name: 'Business email address' })
         .click()
       await this.page.locator("//a[normalize-space()='Sign out']").click()
       break
@@ -649,9 +644,19 @@ Given(
 Then(
   'Verfiy relevant ErrorMessage {string} is displayed',
   async function (errMsg) {
-    const actErrMsg = await this.page
-      .locator("//ul[@class='govuk-list govuk-error-summary__list']//li")
-      .innerText()
+    const errorLocator = this.page.locator(
+      "//ul[@class='govuk-list govuk-error-summary__list']//li"
+    )
+    try {
+      await errorLocator.waitFor({ state: 'visible', timeout: 5000 })
+    } catch {
+      const pageTitle = await this.page.title()
+      const pageUrl = this.page.url()
+      throw new Error(
+        `Error summary not found. Expected: "${errMsg}". Page: "${pageTitle}" (${pageUrl})`
+      )
+    }
+    const actErrMsg = await errorLocator.innerText()
     expect(actErrMsg).toBe(errMsg)
   }
 )


### PR DESCRIPTION
- Check if the proxy caches B2C authorize responses by making the same
request twice and looking for cache headers (X-Cache, Age, Via).

- Reduce timeout to 5s and report expected error, page title, and URL
when error summary is not found, making it easier to debug validation
test failures.