### PR TITLE
Feature/sfd2 284 auto test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ FAILED
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+*.log
+log/
+.env

--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -181,7 +181,7 @@ Feature: Update business details
       | Change | VATnumber |       10 | Enter a VAT registration number, like 123456789 | WhatIsYourVATRegistrationNumber |
 
   @test45 @sfd2-809
-  Scenario Outline: Verify  Application is displaying relevant message whilist selecting Yes or No in AreYouSureYouWantToRemoveYourVATRegistrationNumber page
+  Scenario: Verify  Application is displaying relevant message whilist selecting Yes or No in AreYouSureYouWantToRemoveYourVATRegistrationNumber page
     When I add the VAT Number
     And I click "Remove" link
     And I click VAT submit button

--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -292,3 +292,86 @@ Feature: Update business details
       | Text     | ExpectedHref      |
       | Back     | /business-details |
       | Sign out | /auth/sign-out    |    
+
+  @test58 @sfd2-819
+  Scenario: Verify elements and links are correct on CheckYourBusinessPhoneNumbersAreCorrectBeforeSubmitting page
+    When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
+    And I navigate to the CheckYourBusinessPhoneNumbersAreCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                                            |
+      | Single business identifier (SBI):                               |
+      | Check your business phone numbers are correct before submitting |
+      | Business phone numbers                                          |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref                    |
+      | Back     | /business-phone-numbers-change  |
+      | Sign out | /auth/sign-out                  |
+      | Change   | /business-phone-numbers-change  |    
+
+  @test59 @sfd2-820
+  Scenario: Verify elements and links are correct on WhatIsYourBusinessEmailAddress page
+    When I click the "BusinessEmailAddress" link on the BusinessDetails page
+    Then following texts should be visible:
+      | Text                                 |
+      | Single business identifier (SBI):    |
+      | What is your business email address? |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /business-details |
+      | Sign out | /auth/sign-out    |    
+
+  @test60 @sfd2-821
+  Scenario: Verify elements and links are correct on CheckYourBusinessEmailAddressIsCorrectBeforeSubmitting page
+    When I click the "BusinessEmailAddress" link on the BusinessDetails page
+    And I navigate to the CheckYourBusinessEmailAddressIsCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                                           |
+      | Single business identifier (SBI):                              |
+      | Check your business email address is correct before submitting |
+      | Business email address                                         |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref           |
+      | Back     | /business-email-change |
+      | Sign out | /auth/sign-out         |
+      | Change   | /business-email-change |
+
+  @test61 @sfd2-822
+  Scenario: Verify elements and links are correct on AreYouSureYouWantToRemoveYourVATRegistrationNumber page
+    When I add the VAT Number
+    And I click "Remove" link
+    Then following texts should be visible:
+      | Text                                                         |
+      | Single business identifier (SBI):                            |
+      | Are you sure you want to remove your VAT registration number? |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /business-details |
+      | Sign out | /auth/sign-out    |
+
+  @test62 @sfd2-823
+  Scenario: Verify elements and links are correct on WhatIsYourVATRegistrationNumber page
+    When I navigate to the WhatIsYourVATRegistrationNumber page
+    Then following texts should be visible:
+      | Text                                                                                                                                                                                            |
+      | Single business identifier (SBI):                                                                                                                                                               |
+      | What is your VAT registration number?                                                                                                                                                           |
+      | This is the 9 digit number on your VAT registration certification. You only need to enter the numbers. For example, if your VAT registration number is GB123456789, you should enter 123456789. |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /business-details |
+      | Sign out | /auth/sign-out    |
+
+  @test63 @sfd2-824
+  Scenario: Verify elements and links are correct on CheckYourVATRegistrationNumberIsCorrectBeforeSubmitting page
+    When I navigate to the CheckYourVATRegistrationNumberIsCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                                            |
+      | Single business identifier (SBI):                               |
+      | Check your VAT registration number is correct before submitting |
+      | VAT registration number                                         |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref                            |
+      | Back     | /business-vat-registration-number-change |
+      | Sign out | /auth/sign-out                           |
+      | Change   | /business-vat-registration-number-change |    
+    

--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -374,4 +374,15 @@ Feature: Update business details
       | Back     | /business-vat-registration-number-change |
       | Sign out | /auth/sign-out                           |
       | Change   | /business-vat-registration-number-change |    
-    
+
+  @test75 @sfd2-716
+  Scenario Outline: Verify relevant error message for various validation criteria on WhatIsYourBusinessAddress page
+    When I click the "BusinessAddress" link on the BusinessDetails page
+    And I enter the test data on with value as "<TestData>" on the WhatIsYourBusinessAddress page
+    Then Verfiy relevant ErrorMessage "<ErrorMessage>" is displayed
+
+    Examples:
+      | TestData | ErrorMessage                           |
+      |          | Enter a postcode                       |
+      | BG20 9X  | Enter a full UK postcode, like AA3 1AB |
+      | BG20 9XE | No addresses found for this postcode   |  

--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -179,3 +179,35 @@ Feature: Update business details
       | Change | VATnumber |        8 | Enter a VAT registration number, like 123456789 | WhatIsYourVATRegistrationNumber |
       | Change | VATnumber |          | Enter a VAT registration number                 | WhatIsYourVATRegistrationNumber |
       | Change | VATnumber |       10 | Enter a VAT registration number, like 123456789 | WhatIsYourVATRegistrationNumber |
+
+  @test45 @sfd2-809
+  Scenario Outline: Verify  Application is displaying relevant message whilist selecting Yes or No in AreYouSureYouWantToRemoveYourVATRegistrationNumber page
+    When I add the VAT Number
+    And I click "Remove" link
+    And I click VAT submit button
+    Then error message "Select yes if you want to remove your VAT registration number" on the page AreYouSureYouWantToRemoveYourVATRegistrationNumber page
+
+  @test48 @sfd2-806
+  Scenario Outline: Verify relevant Error message displaying for various validation criterias on WhatAreYourBusinessPhoneNumbers? page
+    When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
+    And I enter the test data on the field "<TextField>" with value as "<TestData>" on the "<ValidationPage>" page
+    Then Verfiy relevant ErrorMessage "<ErrorMessage>" is displayed
+
+    Examples:
+      | TextField              | TestData | ErrorMessage                                                | ValidationPage                  |
+      | BusinessPhone          |       51 | Business telephone number must be 50 characters or less     | WhatAreYourBusinessPhoneNumbers |
+      | BusinessPhone          |        1 | Business telephone number must be 10 characters or more     | WhatAreYourBusinessPhoneNumbers |
+      | BusinessMobilePhone    |       51 | Business mobile phone number must be 50 characters or less  | WhatAreYourBusinessPhoneNumbers |
+      | BusinessMobilePhone    |        1 | Business mobile phone number must be 10 characters or more  | WhatAreYourBusinessPhoneNumbers |
+      | BusinessAndMobilePhone |          | Enter at least one phone number                             | WhatAreYourBusinessPhoneNumbers |
+
+  @test49 @sfd2-806
+  Scenario Outline: Verify relevant Error message displaying for invalid characters on WhatAreYourBusinessPhoneNumbers? page
+    When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
+    And I enter invalid characters "<InvalidChars>" on the "<TextField>" field on the "<ValidationPage>" page
+    Then Verfiy relevant ErrorMessage "<ErrorMessage>" is displayed
+
+    Examples:
+      | TextField           | InvalidChars  | ErrorMessage                                                                                                        | ValidationPage                  |
+      | BusinessPhone       | abc!$%        | Business telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +    | WhatAreYourBusinessPhoneNumbers |
+      | BusinessMobilePhone | abc!$%        | Business mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and + | WhatAreYourBusinessPhoneNumbers |

--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -211,3 +211,84 @@ Feature: Update business details
       | TextField           | InvalidChars  | ErrorMessage                                                                                                        | ValidationPage                  |
       | BusinessPhone       | abc!$%        | Business telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +    | WhatAreYourBusinessPhoneNumbers |
       | BusinessMobilePhone | abc!$%        | Business mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and + | WhatAreYourBusinessPhoneNumbers |
+
+  @test51 @sfd2-812
+  Scenario: Verify Back and Sign out links are correct on WhatIsYourBusinessName page
+    When I click the "BusinessName" link on the BusinessDetails page
+    Then the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /business-details |
+      | Sign out | /auth/sign-out    |
+
+  @test52 @sfd2-813
+  Scenario: Verify Back, Sign out and Change links are correct on CheckYourBusinessNameIsCorrectBeforeSubmitting page
+    When I click the "BusinessName" link on the BusinessDetails page
+    And I navigate to the CheckYourBusinessNameIsCorrectBeforeSubmitting page
+    Then the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref          |
+      | Back     | /business-name-change |
+      | Sign out | /auth/sign-out        |    
+
+  @test53 @sfd2-814
+  Scenario: Verify elements and links are correct on WhatIsYourBusinessAddress page
+    When I click the "BusinessAddress" link on the BusinessDetails page
+    Then following texts should be visible:
+      | Text                                                          |
+      | Single business identifier (SBI):                             |
+      | What is your business address?                                |
+      | If you do not have a UK postcode, enter the address manually. |
+      | UK postcode                                                   |
+    And the following links should have the correct hrefs on the page:
+      | Text                   | ExpectedHref            |
+      | Back                   | /business-details       |
+      | Sign out               | /auth/sign-out          |
+      | Enter address manually | /business-address-enter |
+
+  @test54 @sfd2-815
+  Scenario: Verify elements and links are correct on ChooseYourBusinessAddress page
+    When I click the "BusinessAddress" link on the BusinessDetails page
+    And I enter a valid postcode and continue to ChooseYourBusinessAddress page
+    Then following texts should be visible:
+      | Text                              |
+      | Single business identifier (SBI): |
+      | Choose your business address      |
+      | Select an address                 |
+      | UK postcode                       |
+    And the following links should have the correct hrefs on the page:
+      | Text                   | ExpectedHref             |
+      | Back                   | /business-address-change |
+      | Sign out               | /auth/sign-out           |
+      | Enter address manually | /business-address-enter  |
+      | Change                 | /business-address-change |        
+
+  @test55 @sfd2-815
+  Scenario: Verify business address can be updated using postcode lookup
+    When I click the "BusinessAddress" link on the BusinessDetails page
+    And I enter a valid postcode and continue to ChooseYourBusinessAddress page
+    And I select an address and submit
+    Then Verify Success Updated message is displayed for "BusinessAddress" on the page ViewAndUpdateYourBusinessType  
+
+  @test56 @sfd2-817
+  Scenario: Verify Back, Sign out and Change links are correct on CheckYourBusinessAddressIsCorrectBeforeSubmitting page
+    When I click the "BusinessAddress" link on the BusinessDetails page
+    And I navigate to the CheckYourBusinessAddressIsCorrectBeforeSubmitting page
+    Then the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref            |
+      | Back     | /business-address-enter |
+      | Sign out | /auth/sign-out          |
+      | Change   | /business-address-enter |  
+
+  @test57 @sfd2-818
+  Scenario: Verify elements and links are correct on WhatAreYourBusinessPhoneNumbers page
+    When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
+    Then following texts should be visible:
+      | Text                              |
+      | Single business identifier (SBI): |
+      | What are your business phone numbers? |
+      | Enter at least one phone number   |
+      | Business telephone number         |
+      | Business mobile phone number      |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /business-details |
+      | Sign out | /auth/sign-out    |    

--- a/features/updatePersonalDetails.feature
+++ b/features/updatePersonalDetails.feature
@@ -186,4 +186,128 @@ Feature: Update personal details
     And the following links should have the correct hrefs on the page:
       | Text     | ExpectedHref      |
       | Back     | /personal-details |
-      | Sign out | /auth/sign-out    |    
+      | Sign out | /auth/sign-out    |
+
+  @test66 @sfd2-827
+  Scenario: Verify elements and links are correct on CheckYourNameIsCorrectBeforeSubmitting page
+    When I click the "FullName" link on the "ViewAndUpdateYourPersonalDetails"Page
+    And I navigate to the CheckYourNameIsCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                         |
+      | Check your name is correct before submitting |
+      | Full name                                    |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref         |
+      | Back     | /account-name-change |
+      | Sign out | /auth/sign-out       |
+      | Change   | /account-name-change |    
+
+  @test67 @sfd2-828
+  Scenario: Verify elements and links are correct on WhatIsYourDateOfBirth page
+    When I click the "PersonalDOB" link on the "ViewAndUpdateYourPersonalDetails"Page
+    Then following texts should be visible:
+      | Text                        |
+      | What is your date of birth? |
+      | For example, 31 3 1980      |
+      | Day                         |
+      | Month                       |
+      | Year                        |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /personal-details |
+      | Sign out | /auth/sign-out    |
+
+  @test68 @sfd2-829
+  Scenario: Verify elements and links are correct on CheckYourDateOfBirthIsCorrectBeforeSubmitting page
+    When I click the "PersonalDOB" link on the "ViewAndUpdateYourPersonalDetails"Page
+    And I navigate to the CheckYourDateOfBirthIsCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                                  |
+      | Check your date of birth is correct before submitting |
+      | Date of birth                                         |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref                  |
+      | Back     | /account-date-of-birth-change |
+      | Sign out | /auth/sign-out                |
+      | Change   | /account-date-of-birth-change |
+
+  @test69 @sfd2-830
+  Scenario: Verify elements and links are correct on WhatIsYourPersonalAddress page
+    When I click the "PersonalAddress" link on the "ViewAndUpdateYourPersonalDetails"Page
+    Then following texts should be visible:
+      | Text                                                          |
+      | What is your personal address?                                |
+      | If you do not have a UK postcode, enter the address manually. |
+      | UK postcode                                                   |
+    And the following links should have the correct hrefs on the page:
+      | Text                   | ExpectedHref           |
+      | Back                   | /personal-details      |
+      | Sign out               | /auth/sign-out         |
+      | Enter address manually | /account-address-enter |                
+
+  @test70 @sfd2-832
+  Scenario: Verify elements and links are correct on CheckYourPersonalAddressIsCorrectBeforeSubmitting page
+    When I click the "PersonalAddress" link on the "ViewAndUpdateYourPersonalDetails"Page
+    And I navigate to the CheckYourPersonalAddressIsCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                                     |
+      | Check your personal address is correct before submitting |
+      | Personal address                                         |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref           |
+      | Back     | /account-address-enter |
+      | Sign out | /auth/sign-out         |
+      | Change   | /account-address-enter |
+
+  @test71 @sfd2-833
+  Scenario: Verify elements and links are correct on WhatAreYourPersonalPhoneNumbers page
+    When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
+    Then following texts should be visible:
+      | Text                                  |
+      | What are your personal phone numbers? |
+      | Enter at least one phone number       |
+      | Personal telephone number             |
+      | Personal mobile phone number          |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /personal-details |
+      | Sign out | /auth/sign-out    |
+
+  @test72 @sfd2-834
+  Scenario: Verify elements and links are correct on CheckYourPersonalPhoneNumbersAreCorrectBeforeSubmitting page
+    When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
+    And I navigate to the CheckYourPersonalPhoneNumbersAreCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                                            |
+      | Check your personal phone numbers are correct before submitting |
+      | Personal phone numbers                                          |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref                   |
+      | Back     | /account-phone-numbers-change  |
+      | Sign out | /auth/sign-out                 |
+      | Change   | /account-phone-numbers-change  |            
+
+  @test73 @sfd2-835
+  Scenario: Verify elements and links are correct on WhatIsYourPersonalEmailAddress page
+    When I click the "personalemailaddress" link on the "ViewAndUpdateYourPersonalDetails"Page
+    Then following texts should be visible:
+      | Text                                 |
+      | What is your personal email address? |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /personal-details |
+      | Sign out | /auth/sign-out    |
+
+  @test74 @sfd2-836
+  Scenario: Verify elements and links are correct on CheckYourPersonalEmailAddressIsCorrectBeforeSubmitting page
+    When I click the "personalemailaddress" link on the "ViewAndUpdateYourPersonalDetails"Page
+    And I navigate to the CheckYourPersonalEmailAddressIsCorrectBeforeSubmitting page
+    Then following texts should be visible:
+      | Text                                                           |
+      | Check your personal email address is correct before submitting |
+      | Personal email address                                         |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref          |
+      | Back     | /account-email-change |
+      | Sign out | /auth/sign-out        |
+      | Change   | /account-email-change |        

--- a/features/updatePersonalDetails.feature
+++ b/features/updatePersonalDetails.feature
@@ -173,3 +173,17 @@ Feature: Update personal details
       | TextField               | InvalidChars | ErrorMessage                                                                                                         | ValidationPage                  |
       | PersonalPhone           | abc!$%       | Personal telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +     | WhatAreYourPersonalPhoneNumbers |
       | PersonalMobilePhone     | abc!$%       | Personal mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +  | WhatAreYourPersonalPhoneNumbers |
+
+  @test65 @sfd2-826
+  Scenario: Verify elements and links are correct on WhatIsYourFullName page
+    When I click the "FullName" link on the "ViewAndUpdateYourPersonalDetails"Page
+    Then following texts should be visible:
+      | Text                    |
+      | What is your full name? |
+      | First name              |
+      | Middle names            |
+      | Last name               |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref      |
+      | Back     | /personal-details |
+      | Sign out | /auth/sign-out    |    

--- a/features/updatePersonalDetails.feature
+++ b/features/updatePersonalDetails.feature
@@ -163,3 +163,13 @@ Feature: Update personal details
       | testemailaddress;@email.com | Enter an email address, like name@example.com | WhatIsYourPersonalEmailAddress |
       | testemailaddress[@email.com | Enter an email address, like name@example.com | WhatIsYourPersonalEmailAddress |
       | test emailaddress@email.com | Enter an email address, like name@example.com | WhatIsYourPersonalEmailAddress |
+
+  @test47 @sfd2-807
+  Scenario Outline: Verify relevant Error message displaying for various validation criterias on WhatAreYourPersonalPhoneNumbers? page
+    When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
+    And I enter invalid characters "<InvalidChars>" on the "<TextField>" field on the "<ValidationPage>" page
+    Then Verfiy relevant ErrorMessage "<ErrorMessage>" is displayed
+    Examples:
+      | TextField               | InvalidChars | ErrorMessage                                                                                                         | ValidationPage                  |
+      | PersonalPhone           | abc!$%       | Personal telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +     | WhatAreYourPersonalPhoneNumbers |
+      | PersonalMobilePhone     | abc!$%       | Personal mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +  | WhatAreYourPersonalPhoneNumbers |

--- a/features/viewBusinessDetails.feature
+++ b/features/viewBusinessDetails.feature
@@ -14,5 +14,18 @@ Feature: View business details
       | BusinessLegalStatus | ChangeYourLegalStatus  |
 
   @test50 @sfd2-811
-  Scenario: Verify the View and update your business details page displays all sections and field labels
-    Then the business details page should display all sections and field labels
+  Scenario: Verify all section headings and field labels are displayed on the View and update your business details page
+    Then following texts should be visible:
+      | Text                             |
+      | Business contact details         |
+      | Reference numbers                |
+      | Additional details               |
+      | Business name                    |
+      | Business address                 |
+      | Business phone numbers           |
+      | Business email address           |
+      | Single business identifier (SBI) |
+      | VAT registration number          |
+      | Vendor registration number       |
+      | Business legal status            |
+      | Business type                    |

--- a/features/viewBusinessDetails.feature
+++ b/features/viewBusinessDetails.feature
@@ -12,3 +12,7 @@ Feature: View business details
       | ExpectedLink        | ExpectedPage           |
       | BusinessType        | ChangeYourBusinessType |
       | BusinessLegalStatus | ChangeYourLegalStatus  |
+
+  @test50 @sfd2-811
+  Scenario: Verify the View and update your business details page displays all sections and field labels
+    Then the business details page should display all sections and field labels

--- a/features/viewPersonalDetails.feature
+++ b/features/viewPersonalDetails.feature
@@ -35,3 +35,10 @@ Feature: View personal details
       | Link   |
       | change |
       | back   |
+
+  @test46 @sfd2-808
+  Scenario: Verify error message displays when no address is selected on ChooseYourPersonalAddress page
+    When I click the "personaladdress" link on the "ViewAndUpdateYourPersonalDetails"Page
+    And I enter a valid postcode and continue to the address selection page
+    And I continue without selecting an address on the ChooseYourPersonalAddress page
+    Then Verfiy relevant ErrorMessage "Choose an address" is displayed      

--- a/features/viewPersonalDetails.feature
+++ b/features/viewPersonalDetails.feature
@@ -41,4 +41,19 @@ Feature: View personal details
     When I click the "personaladdress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I enter a valid postcode and continue to the address selection page
     And I continue without selecting an address on the ChooseYourPersonalAddress page
-    Then Verfiy relevant ErrorMessage "Choose an address" is displayed      
+    Then Verfiy relevant ErrorMessage "Choose an address" is displayed
+
+  @test64 @sfd2-825
+  Scenario: Verify all section headings and field labels are displayed on the View and update your personal details page
+    Then following texts should be visible:
+      | Text                                  |
+      | View and update your personal details |
+      | Full name                             |
+      | Date of birth                         |
+      | Customer reference number             |
+      | Personal address                      |
+      | Personal phone numbers                |
+      | Personal email address                |
+    And the following links should have the correct hrefs on the page:
+      | Text     | ExpectedHref   |
+      | Sign out | /auth/sign-out |        

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -1651,40 +1651,6 @@ When(
   }
 )
 
-Then(
-  'the business details page should display all sections and field labels',
-  async function () {
-    // Section headings
-    await expect(
-      this.page.getByText('Business contact details', { exact: true })
-    ).toBeVisible()
-    await expect(
-      this.page.getByText('Reference numbers', { exact: true })
-    ).toBeVisible()
-    await expect(
-      this.page.getByText('Additional details', { exact: true })
-    ).toBeVisible()
-
-    const expectedTerms = [
-      'Business name',
-      'Business address',
-      'Business phone numbers',
-      'Business email address',
-      'Single business identifier (SBI)',
-      'VAT registration number',
-      'Vendor registration number',
-      'Business legal status',
-      'Business type'
-    ]
-
-    for (const label of expectedTerms) {
-      await expect(
-        this.page.getByRole('term').filter({ hasText: label }).first()
-      ).toBeVisible()
-    }
-  }
-)
-
 When(
   'I navigate to the CheckYourBusinessNameIsCorrectBeforeSubmitting page',
   async function () {
@@ -1755,6 +1721,53 @@ When(
     await this.page.fill("//input[@id='country']", 'United Kingdom')
     await this.page.locator("//button[normalize-space()='Continue']").click()
     await this.page.waitForURL('**/business-address-check**')
+  }
+)
+
+When(
+  'I navigate to the CheckYourBusinessPhoneNumbersAreCorrectBeforeSubmitting page',
+  async function () {
+    await this.page.locator('[id="businessTelephone"]').clear()
+    await this.page.fill('#businessTelephone', generateRandomPhoneNumber())
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    // ✅ does not click Submit
+    await this.page.waitForURL('**/business-phone-numbers-check**')
+  }
+)
+
+When(
+  'I navigate to the CheckYourBusinessEmailAddressIsCorrectBeforeSubmitting page',
+  async function () {
+    await this.page.locator('//input[@id="business-email"]').clear()
+    await this.page.fill('//input[@id="business-email"]', generateRandomEmail())
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    // ✅ does not click Submit
+    await this.page.waitForURL('**/business-email-check**')
+  }
+)
+
+When(
+  'I navigate to the WhatIsYourVATRegistrationNumber page',
+  async function () {
+    await this.page
+      .locator('//a[@href="/business-vat-registration-number-change"]')
+      .click()
+    // ✅ stops here — does not fill or continue
+    await this.page.waitForURL('**/business-vat-registration-number-change**')
+  }
+)
+
+When(
+  'I navigate to the CheckYourVATRegistrationNumberIsCorrectBeforeSubmitting page',
+  async function () {
+    await this.page
+      .locator('//a[@href="/business-vat-registration-number-change"]')
+      .click()
+    await this.page.locator('//input[@id="business-vat"]').clear()
+    await this.page.fill('//input[@id="business-vat"]', '123456789')
+    await this.page.locator('//button[normalize-space()="Continue"]').click()
+    // ✅ does not click Submit
+    await this.page.waitForURL('**/business-vat-registration-number-check**')
   }
 )
 

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -1272,9 +1272,9 @@ Given(
 
 Given('I update the dob', async function () {
   const dob = faker.date.birthdate({ min: 18, max: 90, mode: 'age' })
-  const day = (dob.getDate() + 1).toString().padStart(2, '0')
-  const month = (dob.getMonth() + 1).toString().padStart(2, '0')
-  const year = (dob.getFullYear() + 1).toString()
+  const day = String(dob.getUTCDate()).padStart(2, '0')
+  const month = String(dob.getUTCMonth() + 1).padStart(2, '0')
+  const year = String(dob.getUTCFullYear())
 
   await this.page.locator("//input[@id='day']").clear()
   await this.page.fill("//input[@id='day']", day)

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -20,7 +20,13 @@ Given(
           .locator(
             "//a[normalize-space()='View and update your business details']"
           )
+          .waitFor({ state: 'visible' })
+        await this.page
+          .locator(
+            "//a[normalize-space()='View and update your business details']"
+          )
           .click()
+        await this.page.waitForURL('**/business-details')
         break
       case 'personaldetails':
         await loginAsStandardUser(this.page)
@@ -1642,6 +1648,113 @@ When(
   'I continue without selecting an address on the ChooseYourPersonalAddress page',
   async function () {
     await this.page.locator("//button[normalize-space()='Continue']").click()
+  }
+)
+
+Then(
+  'the business details page should display all sections and field labels',
+  async function () {
+    // Section headings
+    await expect(
+      this.page.getByText('Business contact details', { exact: true })
+    ).toBeVisible()
+    await expect(
+      this.page.getByText('Reference numbers', { exact: true })
+    ).toBeVisible()
+    await expect(
+      this.page.getByText('Additional details', { exact: true })
+    ).toBeVisible()
+
+    const expectedTerms = [
+      'Business name',
+      'Business address',
+      'Business phone numbers',
+      'Business email address',
+      'Single business identifier (SBI)',
+      'VAT registration number',
+      'Vendor registration number',
+      'Business legal status',
+      'Business type'
+    ]
+
+    for (const label of expectedTerms) {
+      await expect(
+        this.page.getByRole('term').filter({ hasText: label }).first()
+      ).toBeVisible()
+    }
+  }
+)
+
+When(
+  'I navigate to the CheckYourBusinessNameIsCorrectBeforeSubmitting page',
+  async function () {
+    await this.page.locator('//input[@id="business-name"]').clear()
+    this.businessName = faker.company.name()
+    await this.page.fill('//input[@id="business-name"]', this.businessName)
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    await this.page.waitForURL('**/business-name-check**')
+  }
+)
+
+Then(
+  'the following links should have the correct hrefs on the page:',
+  async function (dataTable) {
+    const rows = dataTable.hashes()
+    for (const { Text, ExpectedHref } of rows) {
+      const link = this.page.locator(`a[href="${ExpectedHref}"]`).filter({
+        hasText: new RegExp(`^\\s*${Text}`, 'i')
+      })
+      await expect(link.first()).toHaveAttribute('href', ExpectedHref)
+    }
+  }
+)
+
+Then('following texts should be visible:', async function (dataTable) {
+  const texts = dataTable.rawTable.slice(1).map((row) => row[0])
+  for (const text of texts) {
+    await expect(
+      this.page.getByText(text, { exact: false }).first()
+    ).toBeVisible()
+  }
+})
+
+When(
+  'I enter a valid postcode and continue to ChooseYourBusinessAddress page',
+  async function () {
+    this.postcode = getRandomUKPostcode()
+    await this.page.locator('//input[@id="postcode"]').fill(this.postcode)
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    await this.page.waitForURL('**/business-address-select**')
+  }
+)
+
+When('I select an address and submit', async function () {
+  const select = '#addresses'
+  await this.page.locator(select).waitFor({ state: 'visible' })
+  const options = await this.page.$$(select + '> option')
+  const randomIndex = Math.floor(Math.random() * (options.length - 1)) + 1
+  await this.page.selectOption(select, { index: randomIndex })
+  await this.page.locator("//button[normalize-space()='Continue']").click()
+  await this.page.locator("//button[normalize-space()='Submit']").click()
+})
+
+When(
+  'I navigate to the CheckYourBusinessAddressIsCorrectBeforeSubmitting page',
+  async function () {
+    await this.page
+      .locator("//a[normalize-space()='Enter address manually']")
+      .click()
+    await this.page.locator('//input[@id="address-1"]').clear()
+    await this.page.fill(
+      '//input[@id="address-1"]',
+      faker.location.streetAddress()
+    )
+    await this.page.locator("//input[@id='city']").clear()
+    await this.page.fill("//input[@id='city']", faker.location.city())
+    await this.page.locator("//input[@id='country']").clear()
+    await this.page.fill("//input[@id='country']", 'United Kingdom')
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    await this.page.waitForURL('**/business-address-check**')
   }
 )
 

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -1575,9 +1575,7 @@ Then(
 )
 
 When('I click VAT submit button', async function () {
-  await this.page
-    .locator('#main-content > div.govuk-grid-row > div > form > button')
-    .click()
+  await this.page.locator("//button[normalize-space()='Submit']").click()
   await this.page.waitForLoadState('domcontentloaded')
 })
 
@@ -1730,7 +1728,6 @@ When(
     await this.page.locator('[id="businessTelephone"]').clear()
     await this.page.fill('#businessTelephone', generateRandomPhoneNumber())
     await this.page.locator("//button[normalize-space()='Continue']").click()
-    // ✅ does not click Submit
     await this.page.waitForURL('**/business-phone-numbers-check**')
   }
 )
@@ -1741,7 +1738,6 @@ When(
     await this.page.locator('//input[@id="business-email"]').clear()
     await this.page.fill('//input[@id="business-email"]', generateRandomEmail())
     await this.page.locator("//button[normalize-space()='Continue']").click()
-    // ✅ does not click Submit
     await this.page.waitForURL('**/business-email-check**')
   }
 )
@@ -1752,7 +1748,6 @@ When(
     await this.page
       .locator('//a[@href="/business-vat-registration-number-change"]')
       .click()
-    // ✅ stops here — does not fill or continue
     await this.page.waitForURL('**/business-vat-registration-number-change**')
   }
 )
@@ -1766,7 +1761,6 @@ When(
     await this.page.locator('//input[@id="business-vat"]').clear()
     await this.page.fill('//input[@id="business-vat"]', '123456789')
     await this.page.locator('//button[normalize-space()="Continue"]').click()
-    // ✅ does not click Submit
     await this.page.waitForURL('**/business-vat-registration-number-check**')
   }
 )
@@ -1781,7 +1775,6 @@ When(
     await this.page.fill('//input[@id="middle"]', faker.person.middleName())
     await this.page.fill('//input[@id="last"]', faker.person.lastName())
     await this.page.locator("//button[normalize-space()='Continue']").click()
-    // ✅ does not click Submit
     await this.page.waitForURL('**/account-name-check**')
   }
 )
@@ -1790,9 +1783,9 @@ When(
   'I navigate to the CheckYourDateOfBirthIsCorrectBeforeSubmitting page',
   async function () {
     const dob = faker.date.birthdate({ min: 18, max: 90, mode: 'age' })
-    const day = (dob.getDate() + 1).toString().padStart(2, '0')
-    const month = (dob.getMonth() + 1).toString().padStart(2, '0')
-    const year = (dob.getFullYear() + 1).toString()
+    const day = String(dob.getUTCDate()).padStart(2, '0')
+    const month = String(dob.getUTCMonth() + 1).padStart(2, '0')
+    const year = String(dob.getUTCFullYear())
     await this.page.locator("//input[@id='day']").clear()
     await this.page.fill("//input[@id='day']", day)
     await this.page.locator("//input[@id='month']").clear()
@@ -1800,7 +1793,6 @@ When(
     await this.page.locator("//input[@id='year']").clear()
     await this.page.fill("//input[@id='year']", year)
     await this.page.locator("//button[normalize-space()='Continue']").click()
-    // ✅ does not click Submit
     await this.page.waitForURL('**/account-date-of-birth-check**')
   }
 )
@@ -1821,7 +1813,6 @@ When(
     await this.page.locator("//input[@id='country']").clear()
     await this.page.fill("//input[@id='country']", 'United Kingdom')
     await this.page.locator("//button[normalize-space()='Continue']").click()
-    // ✅ does not click Submit or Change
     await this.page.waitForURL('**/account-address-check**')
   }
 )
@@ -1832,7 +1823,6 @@ When(
     await this.page.locator('[id="personalTelephone"]').clear()
     await this.page.fill('#personalTelephone', generateRandomPhoneNumber())
     await this.page.locator("//button[normalize-space()='Continue']").click()
-    // ✅ does not click Submit
     await this.page.waitForURL('**/account-phone-numbers-check**')
   }
 )
@@ -1843,7 +1833,6 @@ When(
     await this.page.locator('//input[@id="personal-email"]').clear()
     await this.page.fill('//input[@id="personal-email"]', generateRandomEmail())
     await this.page.locator("//button[normalize-space()='Continue']").click()
-    // ✅ does not click Submit
     await this.page.waitForURL('**/account-email-check**')
   }
 )

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -683,6 +683,14 @@ Given(
           .click()
         break
 
+      case 'businessmobilephone':
+        await this.page.locator('#businessMobile').clear()
+        await this.page.fill('#businessMobile', this.generateValue)
+        await this.page
+          .locator("//button[normalize-space()='Continue']")
+          .click()
+        break
+
       case 'businessandmobilephone':
         await this.page.locator('[id="businessTelephone"]').clear()
         await this.page.fill('#businessTelephone', this.generateValue)
@@ -1560,6 +1568,83 @@ Then(
   }
 )
 
+When('I click VAT submit button', async function () {
+  await this.page
+    .locator('#main-content > div.govuk-grid-row > div > form > button')
+    .click()
+  await this.page.waitForLoadState('domcontentloaded')
+})
+
+Then(
+  'error message {string} on the page AreYouSureYouWantToRemoveYourVATRegistrationNumber page',
+  async function (errorMessage) {
+    await this.page
+      .locator('.govuk-error-summary')
+      .waitFor({ state: 'visible' })
+    const errorText = await this.page
+      .locator('.govuk-error-summary')
+      .textContent()
+    expect(errorText).toContain(errorMessage)
+  }
+)
+
+When(
+  'I enter invalid characters {string} on the {string} field on the {string} page',
+  async function (invalidChars, field, _page) {
+    switch (field.toLowerCase()) {
+      case 'personalphone':
+        await this.page.locator('//input[@id="personalTelephone"]').clear()
+        await this.page.fill('//input[@id="personalTelephone"]', invalidChars)
+        await this.page
+          .locator('//button[normalize-space()="Continue"]')
+          .click()
+        break
+
+      case 'personalmobilephone':
+        await this.page.locator('//input[@id="personalMobile"]').clear()
+        await this.page.fill('//input[@id="personalMobile"]', invalidChars)
+        await this.page
+          .locator('//button[normalize-space()="Continue"]')
+          .click()
+        break
+
+      case 'businessphone':
+        await this.page.locator('#businessTelephone').clear()
+        await this.page.fill('#businessTelephone', invalidChars)
+        await this.page
+          .locator("//button[normalize-space()='Continue']")
+          .click()
+        break
+
+      case 'businessmobilephone':
+        await this.page.locator('#businessMobile').clear()
+        await this.page.fill('#businessMobile', invalidChars)
+        await this.page
+          .locator("//button[normalize-space()='Continue']")
+          .click()
+        break
+
+      default:
+        throw new Error(`Unknown field: ${field}`)
+    }
+  }
+)
+
+When(
+  'I enter a valid postcode and continue to the address selection page',
+  async function () {
+    await this.page.locator("//input[@id='postcode']").fill('SW1A 1AA')
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+  }
+)
+
+When(
+  'I continue without selecting an address on the ChooseYourPersonalAddress page',
+  async function () {
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+  }
+)
+
 function generateRandomPhoneNumber() {
   let phone = '0'
   for (let i = 0; i < 10; i++) phone += Math.floor(Math.random() * 10)
@@ -1670,6 +1755,7 @@ function generateValidationTestData(field, length) {
         value += faker.person.lastName()
         break
       case 'businessphone':
+      case 'businessmobilephone':
       case 'personalphone':
       case 'personalmobilephone':
         value += generateRandomPhoneNumber()

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -1771,6 +1771,92 @@ When(
   }
 )
 
+When(
+  'I navigate to the CheckYourNameIsCorrectBeforeSubmitting page',
+  async function () {
+    await this.page.locator('//input[@id="first"]').clear()
+    await this.page.locator('//input[@id="middle"]').clear()
+    await this.page.locator('//input[@id="last"]').clear()
+    await this.page.fill('//input[@id="first"]', faker.person.firstName())
+    await this.page.fill('//input[@id="middle"]', faker.person.middleName())
+    await this.page.fill('//input[@id="last"]', faker.person.lastName())
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    // ✅ does not click Submit
+    await this.page.waitForURL('**/account-name-check**')
+  }
+)
+
+When(
+  'I navigate to the CheckYourDateOfBirthIsCorrectBeforeSubmitting page',
+  async function () {
+    const dob = faker.date.birthdate({ min: 18, max: 90, mode: 'age' })
+    const day = (dob.getDate() + 1).toString().padStart(2, '0')
+    const month = (dob.getMonth() + 1).toString().padStart(2, '0')
+    const year = (dob.getFullYear() + 1).toString()
+    await this.page.locator("//input[@id='day']").clear()
+    await this.page.fill("//input[@id='day']", day)
+    await this.page.locator("//input[@id='month']").clear()
+    await this.page.fill("//input[@id='month']", month)
+    await this.page.locator("//input[@id='year']").clear()
+    await this.page.fill("//input[@id='year']", year)
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    // ✅ does not click Submit
+    await this.page.waitForURL('**/account-date-of-birth-check**')
+  }
+)
+
+When(
+  'I navigate to the CheckYourPersonalAddressIsCorrectBeforeSubmitting page',
+  async function () {
+    await this.page
+      .locator("//a[normalize-space()='Enter address manually']")
+      .click()
+    await this.page.locator('//input[@id="address1"]').clear()
+    await this.page.fill(
+      '//input[@id="address1"]',
+      faker.location.streetAddress()
+    )
+    await this.page.locator("//input[@id='city']").clear()
+    await this.page.fill("//input[@id='city']", faker.location.city())
+    await this.page.locator("//input[@id='country']").clear()
+    await this.page.fill("//input[@id='country']", 'United Kingdom')
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    // ✅ does not click Submit or Change
+    await this.page.waitForURL('**/account-address-check**')
+  }
+)
+
+When(
+  'I navigate to the CheckYourPersonalPhoneNumbersAreCorrectBeforeSubmitting page',
+  async function () {
+    await this.page.locator('[id="personalTelephone"]').clear()
+    await this.page.fill('#personalTelephone', generateRandomPhoneNumber())
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    // ✅ does not click Submit
+    await this.page.waitForURL('**/account-phone-numbers-check**')
+  }
+)
+
+When(
+  'I navigate to the CheckYourPersonalEmailAddressIsCorrectBeforeSubmitting page',
+  async function () {
+    await this.page.locator('//input[@id="personal-email"]').clear()
+    await this.page.fill('//input[@id="personal-email"]', generateRandomEmail())
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+    // ✅ does not click Submit
+    await this.page.waitForURL('**/account-email-check**')
+  }
+)
+
+When(
+  'I enter the test data on with value as {string} on the WhatIsYourBusinessAddress page',
+  async function (testData) {
+    await this.page.locator("//input[@id='postcode']").clear()
+    await this.page.fill("//input[@id='postcode']", testData)
+    await this.page.locator("//button[normalize-space()='Continue']").click()
+  }
+)
+
 function generateRandomPhoneNumber() {
   let phone = '0'
   for (let i = 0; i < 10; i++) phone += Math.floor(Math.random() * 10)


### PR DESCRIPTION
## Description

This change adds test automation coverage for tickets SFD2-716 and SFD2-806 through SFD2-836, continuing the build-out of the test suite across business and personal details journeys.

---

## Tickets Covered

### Business Details — Elements & Links
| Ticket | Page | Notes |
|---|---|---|
| SFD2-811 | View and update your business details | Refactored to use generic data table step |
| SFD2-812 | What is your business name? | Links only, page covered by existing flows |
| SFD2-813 | Check your business name is correct before submitting | Links only, page covered by existing flows |
| SFD2-814 | What is your business address? | Full elements + links, page not previously asserted |
| SFD2-815 | Choose your business address | Full elements + links + postcode lookup happy path (SFD2-174 AC2) |
| SFD2-816 | Enter your business address | ❌ Closed as redundant, comprehensively covered by existing tests |
| SFD2-817 | Check your business address is correct before submitting | Links only, page covered by existing flows |
| SFD2-818 | What are your business phone numbers? | Full elements + links |
| SFD2-819 | Check your business phone numbers are correct before submitting | Elements + links, inline value labels dropped |
| SFD2-820 | What is your business email address? | Elements + links |
| SFD2-821 | Check your business email address is correct before submitting | Elements + links |
| SFD2-822 | Are you sure you want to remove your VAT registration number? | Elements + links, Yes/No covered by @test18 |
| SFD2-823 | What is your VAT registration number? | Full elements + links including hint text |
| SFD2-824 | Check your VAT registration number is correct before submitting | Elements + links |

### Personal Details — Elements & Links
| Ticket | Page | Notes |
|---|---|---|
| SFD2-825 | View and update your personal details | Full elements + sign out link |
| SFD2-826 | What is your full name? | Full elements + links |
| SFD2-827 | Check your name is correct before submitting | Elements + links |
| SFD2-828 | What is your date of birth? | Full elements + links including hint text |
| SFD2-829 | Check your date of birth is correct before submitting | Elements + links |
| SFD2-830 | What is your personal address? | Elements + links, postcode lookup already covered by @test30 |
| SFD2-831 | Enter your personal address | ❌ Closed as redundant, comprehensively covered by existing tests |
| SFD2-832 | Check your personal address is correct before submitting | Elements + links |
| SFD2-833 | What are your personal phone numbers? | Full elements + links |
| SFD2-834 | Check your personal phone numbers are correct before submitting | Elements + links — inline value labels dropped |
| SFD2-835 | What is your personal email address? | Elements + links |
| SFD2-836 | Check your personal email address is correct before submitting | Elements + links |

### Validation
| Ticket | Page | Notes |
|---|---|---|
| SFD2-716 | What is your business address? | Postcode validation, empty + invalid format. "No addresses found" case deferred — API dependent, see ticket for detail |
| SFD2-806 | What are your business phone numbers? | Invalid character validation, genuine bugs found, failing tests left intentionally. See SFD2-1082 |

---
