### PR TITLE
fix: remove race conditions

### DIFF
--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -3,35 +3,35 @@ Feature: Update business details
   Background:
     Given I am on SignIn page and enter the credentials for "BusinessDetails"
 
-  @test1 @sfd175
+  @test1 @sfd175 @serial
   Scenario: Verify phone number gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
     And I update phone number
     Then Verfiy updated phone details on the ViewAndUpdateYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessPhoneNumbers" on the page ViewAndUpdateYourBusinessType
 
-  @test2 @sfd175
+  @test2 @sfd175 @serial
   Scenario: Verify email gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessEmailAddress" link on the BusinessDetails page
     And I update Email
     Then Verfiy Updated email details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessEmailAddress" on the page ViewAndUpdateYourBusinessType
 
-  @test3 @sfd174
+  @test3 @sfd174 @serial
   Scenario: Verify postal address gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessAddress" link on the BusinessDetails page
     And I update Business Address
     Then Verfiy Updated Business Address details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessAddress" on the page ViewAndUpdateYourBusinessType
 
-  @test4 @sfd174
+  @test4 @sfd174 @serial
   Scenario: Verify business name gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessName" link on the BusinessDetails page
     And I update Business Name
     Then Verfiy Updated Business Name details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessName" on the page ViewAndUpdateYourBusinessType
 
-  @test9 @sfd285
+  @test9 @sfd285 @serial
   Scenario: Verify business name gets updated again by clicking change link on CheckYourBusinessNameIsCorrectBeforeSubmitting page
     When I click the "BusinessName" link on the BusinessDetails page
     And I update Business Name and click the Change link in CheckYourBusinessNameIsCorrectBeforeSubmitting Page
@@ -39,7 +39,7 @@ Feature: Update business details
     Then Verfiy Updated Business Name details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessName" on the page ViewAndUpdateYourBusinessType
 
-  @test10 @sfd285
+  @test10 @sfd285 @serial
   Scenario: Verify postal address gets updated again by clicking change link on EnterYourBusinessAddress page
     When I click the "BusinessAddress" link on the BusinessDetails page
     And I update Business Address and click the Change link in CheckYourBusinessAddressIsCorrectBeforeSubmitting Page
@@ -47,7 +47,7 @@ Feature: Update business details
     Then Verfiy Updated Business Address details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessAddress" on the page ViewAndUpdateYourBusinessType
 
-  @test11 @sfd287
+  @test11 @sfd287 @serial
   Scenario: Verify phone number gets updated again by clicking change link on CheckYourBusinessPhoneNumbersAreCorrectBeforeSubmitting page
     When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
     And I update Business PhoneNumber and click the Change link in CheckYourBusinessPhoneNumbersAreCorrectBeforeSubmitting Page
@@ -55,7 +55,7 @@ Feature: Update business details
     Then Verfiy Updated Business PhoneNumber details on the ViewAndUpdateYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessPhonenumbers" on the page ViewAndUpdateYourBusinessType
 
-  @test12 @sfd287
+  @test12 @sfd287 @serial
   Scenario: Verify business email address gets updated again by clicking change link on CheckYourBusinessEmailAddressIsCorrectBeforeSubmitting page
     When I click the "BusinessEmailAddress" link on the BusinessDetails page
     And I update Business EmailAddress and click the Change link in CheckYourBusinessEmailAddressIsCorrectBeforeSubmitting Page
@@ -92,7 +92,7 @@ Feature: Update business details
       | WhatIsYourBusinessEmailAddress  |
       | ChangeYourBusinessType          |
 
-  @test18 @sfd325
+  @test18 @sfd325 @serial
   Scenario Outline: Verify application displays relevant message when selecting Yes or No on AreYouSureYouWantToRemoveYourVATRegistrationNumber page
     When I add the VAT Number
     And I click "<Link>" link
@@ -104,7 +104,7 @@ Feature: Update business details
       | Yes                   | Remove |
       | No                    | Remove |
 
-  @test19 @sfd383
+  @test19 @sfd383 @serial
   Scenario Outline: Verify updated VAT number is displayed on ViewAndUpdateYourBusinessType page
     When I add the VAT Number
     And I click "<Link>" link
@@ -180,7 +180,7 @@ Feature: Update business details
       | Change | VATnumber |          | Enter a VAT registration number                 | WhatIsYourVATRegistrationNumber |
       | Change | VATnumber |       10 | Enter a VAT registration number, like 123456789 | WhatIsYourVATRegistrationNumber |
 
-  @test45 @sfd2-809
+  @test45 @sfd2-809 @serial
   Scenario: Verify  Application is displaying relevant message whilist selecting Yes or No in AreYouSureYouWantToRemoveYourVATRegistrationNumber page
     When I add the VAT Number
     And I click "Remove" link
@@ -261,7 +261,7 @@ Feature: Update business details
       | Enter address manually | /business-address-enter  |
       | Change                 | /business-address-change |        
 
-  @test55 @sfd2-815
+  @test55 @sfd2-815 @serial
   Scenario: Verify business address can be updated using postcode lookup
     When I click the "BusinessAddress" link on the BusinessDetails page
     And I enter a valid postcode and continue to ChooseYourBusinessAddress page

--- a/features/updatePersonalDetails.feature
+++ b/features/updatePersonalDetails.feature
@@ -3,7 +3,7 @@ Feature: Update personal details
   Background:
     Given I am on SignIn page and enter the credentials for "PersonalDetails"
 
-  @test21 @sfd351
+  @test21 @sfd351 @serial
   Scenario: Verify personal phone number gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal phone number
@@ -25,7 +25,7 @@ Feature: Update personal details
     Then Verfiy Updated Personal Full Name details on the ViewAndUpdateYourPersonalDetails page are been displayed correctly
     And Verify Success Updated message is displayed for "FullName" on the page ViewAndUpdateYourPersonalDetails page
 
-  @test26 @sfd349
+  @test26 @sfd349 @serial
   Scenario Outline: Verify personal postal address gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "PersonalAddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I Update the Personal address "<AddressType>"
@@ -36,20 +36,20 @@ Feature: Update personal details
       | Manually       |
       | PostcodeLookup |
 
-  @test27 @sfd349
+  @test27 @sfd349 @serial
   Scenario: Verify personal postal address gets updated again by clicking change link on CheckYourPersonalAddressIsCorrectBeforeSubmitting page
     When I click the "PersonalAddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal Address Manually and click the Change link in CheckYourPersonalAddressIsCorrectBeforeSubmitting Page
     And Change the Personal Address Manually again in EnterYourPersonalAddress Page
     Then Verfiy updated Personal Address Manually changed details on the ViewAndUpdateYourPersonalDetails page are been displayed correctly
 
-  @test30 @sfd350
+  @test30 @sfd350 @serial
   Scenario: Verify personal date of birth gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "PersonalDOB" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update the dob
     And Verify Success Updated message is displayed for "DOB" on the page ViewAndUpdateYourPersonalDetails page
 
-  @test34 @sfd348
+  @test34 @sfd348 @serial
   Scenario: Verify personal email address gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "personalemailaddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal Email

--- a/features/viewPersonalDetails.feature
+++ b/features/viewPersonalDetails.feature
@@ -3,7 +3,7 @@ Feature: View personal details
   Background:
     Given I am on SignIn page and enter the credentials for "PersonalDetails"
 
-  @test25 @sfd386
+  @test25 @sfd386 @serial
   Scenario Outline: Verify previously entered phone details are retained when navigating back from CheckYourPersonalPhoneNumbersAreCorrectBeforeSubmitting page
     When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal phone number and click the "<Link>" in the CheckYourPersonalPhoneNumbersAreCorrectBeforeSubmitting page
@@ -14,7 +14,7 @@ Feature: View personal details
       | change |
       | back   |
 
-  @test31 @sfd350
+  @test31 @sfd350 @serial
   Scenario Outline: Verify previously entered date of birth details are retained when navigating back from CheckYourDateOfBirthIsCorrectBeforeSubmitting page
     When I click the "PersonalDOB" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal DateOfBirth and click the "<Link>" in the CheckYourDateOfBirthIsCorrectBeforeSubmitting page
@@ -25,7 +25,7 @@ Feature: View personal details
       | change |
       | back   |
 
-  @test35 @sfd348
+  @test35 @sfd348 @serial
   Scenario Outline: Verify previously entered personal email address is retained when navigating back from CheckYourPersonalEmailAddressIsCorrectBeforeSubmitting page
     When I click the "personalemailaddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal email address and click the "<Link>" in the CheckYourPersonalEmailAddressIsCorrectBeforeSubmitting page


### PR DESCRIPTION
Add @serial tag to all data-mutating tests to prevent race conditions

Summary

- Tagged all scenarios that write to shared test user accounts with @serial across updateBusinessDetails.feature, updatePersonalDetails.feature, and viewPersonalDetails.feature
- This ensures tests that mutate the same backend data (business name, address, phone, email, DOB, VAT) run sequentially rather than in parallel with 4 workers
- Validation-only tests (error messages, link checks, element verification) remain parallel as they don't modify shared state

Context

The business name test (@test9) was intermittently failing because parallel workers were simultaneously updating the same user's business name — one test would assert a value that another test had already overwritten. Same risk existed for all other update flows.

This follows the same pattern established in PR #72 for @test22/@test23.