### PR TITLE
fix(#fls2-68): fix input length

### DIFF
--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -202,15 +202,15 @@ Feature: Update business details
       | BusinessAndMobilePhone |          | Enter at least one phone number                             | WhatAreYourBusinessPhoneNumbers |
 
   @test49 @sfd2-806
-  Scenario Outline: Verify relevant Error message displaying for invalid characters on WhatAreYourBusinessPhoneNumbers? page
+  Scenario Outline: Verify format error displays for invalid characters (over 10 chars) on WhatAreYourBusinessPhoneNumbers? page
     When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
     And I enter invalid characters "<InvalidChars>" on the "<TextField>" field on the "<ValidationPage>" page
     Then Verfiy relevant ErrorMessage "<ErrorMessage>" is displayed
 
     Examples:
-      | TextField           | InvalidChars  | ErrorMessage                                                                                                        | ValidationPage                  |
-      | BusinessPhone       | abc!$%        | Business telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +    | WhatAreYourBusinessPhoneNumbers |
-      | BusinessMobilePhone | abc!$%        | Business mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and + | WhatAreYourBusinessPhoneNumbers |
+      | TextField           | InvalidChars | ErrorMessage                                                                                                        | ValidationPage                  |
+      | BusinessPhone       | abc!$%abc!$% | Business telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +    | WhatAreYourBusinessPhoneNumbers |
+      | BusinessMobilePhone | abc!$%abc!$% | Business mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and + | WhatAreYourBusinessPhoneNumbers |
 
   @test51 @sfd2-812
   Scenario: Verify Back and Sign out links are correct on WhatIsYourBusinessName page

--- a/features/updatePersonalDetails.feature
+++ b/features/updatePersonalDetails.feature
@@ -165,14 +165,14 @@ Feature: Update personal details
       | test emailaddress@email.com | Enter an email address, like name@example.com | WhatIsYourPersonalEmailAddress |
 
   @test47 @sfd2-807
-  Scenario Outline: Verify relevant Error message displaying for various validation criterias on WhatAreYourPersonalPhoneNumbers? page
+  Scenario Outline: Verify format error displays for invalid characters (over 10 chars) on WhatAreYourPersonalPhoneNumbers? page
     When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I enter invalid characters "<InvalidChars>" on the "<TextField>" field on the "<ValidationPage>" page
     Then Verfiy relevant ErrorMessage "<ErrorMessage>" is displayed
     Examples:
       | TextField               | InvalidChars | ErrorMessage                                                                                                         | ValidationPage                  |
-      | PersonalPhone           | abc!$%       | Personal telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +     | WhatAreYourPersonalPhoneNumbers |
-      | PersonalMobilePhone     | abc!$%       | Personal mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +  | WhatAreYourPersonalPhoneNumbers |
+      | PersonalPhone           | abc!$%abc!$% | Personal telephone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +     | WhatAreYourPersonalPhoneNumbers |
+      | PersonalMobilePhone     | abc!$%abc!$% | Personal mobile phone number must only include numbers 0 to 9 and special characters such as spaces, brackets and +  | WhatAreYourPersonalPhoneNumbers |
 
   @test65 @sfd2-826
   Scenario: Verify elements and links are correct on WhatIsYourFullName page


### PR DESCRIPTION
This should fix the issue of not getting the expected error message when inputting invalid characters:

> If there's more than one error, show the highest priority error message. In order of priority, show error messages about:
> - missing or incomplete information
> - information that cannot be correct (for example, the number '13' in the month field)
> - information that fails validation for another reason