### PR TITLE
chore: pin GitHub Actions to commit SHAs and standardise .npmrc

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Test code and Create Test Coverage Reports
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -33,4 +33,4 @@ jobs:
 #    name: Run Journey Tests
 #    runs-on: ubuntu-latest
 #    steps:
-#      - uses: DEFRA/cdp-node-journey-test-suite-template/run-journey-tests@main
+#      - uses: DEFRA/cdp-node-journey-test-suite-template/run-journey-tests@0fbf0772fed6bddd2ca9c9722c188b0adf2a2907 # main

--- a/.github/workflows/journey-tests.yml
+++ b/.github/workflows/journey-tests.yml
@@ -12,4 +12,4 @@ jobs:
     name: Run Journey Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: DEFRA/cdp-node-journey-test-suite-template/run-journey-tests@main
+      - uses: DEFRA/cdp-node-journey-test-suite-template/run-journey-tests@0fbf0772fed6bddd2ca9c9722c188b0adf2a2907 # main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build the test suite
-        uses: DEFRA/cdp-build-action/build-test@main
+        uses: DEFRA/cdp-build-action/build-test@7fe324bec9987c5a4d0f4724b42e30c282892ceb # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+git-tag-version=false
 save-exact=true
 ignore-scripts=true
 min-release-age=7


### PR DESCRIPTION
- Pin all GitHub Actions to specific commit SHAs for supply chain security
- Standardise .npmrc with git-tag-version=false, save-exact=true, ignore-scripts=true, min-release-age=7