### PR TITLE
Remove hardcoded SBI assertions

### DIFF
--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -29,7 +29,7 @@ export async function loginAsAmendPermissionUser(page) {
   await page.locator("//button[@id='next']").click()
   await page
     .locator(
-      '//label[normalize-space()="Joseph Heap Property Limited - SBI 107176577"]'
+      `//label[contains(normalize-space(), "SBI ${process.env.USER_AMEND_SBI}")]`
     )
     .click()
   await page.locator("//button[@id='continueReplacement']").click()
@@ -42,6 +42,10 @@ export async function loginAsViewPermissionUser(page) {
     .locator("//input[@id='password']")
     .fill(process.env.USER_VIEW_PASSWORD)
   await page.locator("//button[@id='next']").click()
-  await page.locator("label:has-text('Chefnalls - SBI 113912887')").click()
+  await page
+    .locator(
+      `//label[contains(normalize-space(), "SBI ${process.env.USER_VIEW_SBI}")]`
+    )
+    .click()
   await page.locator('#continueReplacement').click()
 }


### PR DESCRIPTION
## Description

Fixes login failures in `businessDetailsPermissions.feature` caused by hardcoded business name strings in `helpers.js`. Replaces hardcoded labels with env var driven SBI selectors so login remains stable if user data changes in the test environment.

<img width="818" height="956" alt="image" src="https://github.com/user-attachments/assets/47c6bbbf-d69f-4100-9824-482568fcbc88" />


Also replaced the three broken test users (`3020000000`, `3010003000`, `3010001000`) with new working users for `TEST` env in CDP config. 

**Environment variables added (CDP config)**
`USER_STANDARD_CRN`
`USER_AMEND_CRN`
`USER_AMEND_SBI`
`USER_VIEW_CRN`
`USER_VIEW_SBI`

Closes FLS2-166


---

## Changes

**`tests/helpers/helpers.js`**
- Replaced hardcoded `"Joseph Heap Property Limited - SBI 107176577"` label in `loginAsAmendPermissionUser` with env var driven SBI selector using `USER_AMEND_SBI`
- Replaced hardcoded `"Chefnalls - SBI 113912887"` label in `loginAsViewPermissionUser` with env var driven SBI selector using `USER_VIEW_SBI`



