### PR TITLE
Resolve parallel execution failures with per-worker test users - use …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-fcp-sfd-auto-test-suite
-test again1
-The template to create a service that runs WDIO tests against an environment.
+# fcp-sfd-auto-test-suite
 
-- [Local](#local)
+Automated end-to-end test suite for the FCP SFD (Single Front Door) service, built with Playwright and Cucumber. Tests run against the deployed environment and cover the business and personal details journeys.
+
+- [Local Development](#local-development)
   - [Requirements](#requirements)
     - [Node.js](#nodejs)
   - [Setup](#setup)
-  - [Running local tests](#running-local-tests)
-  - [Debugging local tests](#debugging-local-tests)
+  - [Test Users and Environment Variables](#test-users-and-environment-variables)
+  - [Running tests](#running-tests)
+  - [Viewing reports](#viewing-reports)
 - [Production](#production)
-  - [Debugging tests](#debugging-tests)
+- [BrowserStack](#browserstack)
 - [Licence](#licence)
   - [About the licence](#about-the-licence)
 
@@ -32,71 +33,122 @@ nvm use 22.13.1
 npm ci
 ```
 
-A .nvmrc file is included at the repository root to make `nvm use` select the correct version automatically.
+A `.nvmrc` file is included at the repository root to make `nvm use` select the correct version automatically.
 
 ### Setup
 
-Install application dependencies:
+Install dependencies:
 
 ```bash
 npm install
 ```
 
-### Running local tests
+### Test Users and Environment Variables
 
-Start application you are testing on the url specified in `baseUrl` [wdio.local.conf.js](wdio.local.conf.js)
+The suite runs at `parallel: 4` and requires a dedicated test user per worker to prevent login session conflicts and data contention. Users are selected automatically based on `CUCUMBER_WORKER_ID` (set by Cucumber for each parallel worker, values 0-3).
+
+Three user types are required, four of each:
+
+- **Standard** - full permissions, can view and amend all business and personal detail fields. Single business.
+- **Amend** - amend permission level, can amend a subset of business fields. Must have multiple businesses associated.
+- **View** - view only permission, cannot amend any fields. Must have multiple businesses associated.
+
+Amend and view users must have **multiple businesses** associated with their CRN. Single-business users skip the business selection page after login, which causes the SBI-based selection step to time out.
+
+The following environment variables must be set locally (e.g. in `~/.zshrc` or a `.env` file) and as CDP platform config for each environment.
+
+**Standard users** (single business, full permissions)
+
+| Worker | Variables                |
+| ------ | ------------------------ |
+| 1      | `USER_STANDARD_1_CRN`    |
+| 2      | `USER_STANDARD_2_CRN`    |
+| 3      | `USER_STANDARD_3_CRN`    |
+| 4      | `USER_STANDARD_4_CRN`    |
+| All    | `USER_STANDARD_PASSWORD` |
+
+**Amend users** (multi-business, amend permission)
+
+| Worker | Variables                              |
+| ------ | -------------------------------------- |
+| 1      | `USER_AMEND_1_CRN`, `USER_AMEND_1_SBI` |
+| 2      | `USER_AMEND_2_CRN`, `USER_AMEND_2_SBI` |
+| 3      | `USER_AMEND_3_CRN`, `USER_AMEND_3_SBI` |
+| 4      | `USER_AMEND_4_CRN`, `USER_AMEND_4_SBI` |
+| All    | `USER_AMEND_PASSWORD`                  |
+
+**View users** (multi-business, view permission)
+
+| Worker | Variables                            |
+| ------ | ------------------------------------ |
+| 1      | `USER_VIEW_1_CRN`, `USER_VIEW_1_SBI` |
+| 2      | `USER_VIEW_2_CRN`, `USER_VIEW_2_SBI` |
+| 3      | `USER_VIEW_3_CRN`, `USER_VIEW_3_SBI` |
+| 4      | `USER_VIEW_4_CRN`, `USER_VIEW_4_SBI` |
+| All    | `USER_VIEW_PASSWORD`                 |
+
+**Environment**
+
+| Variable      | Description                                       |
+| ------------- | ------------------------------------------------- |
+| `ENVIRONMENT` | Target environment, defaults to `test` if not set |
+
+Test user permission levels are managed via CHS.
+
+#### How worker isolation works
+
+`CUCUMBER_WORKER_ID` is set automatically by Cucumber-JS for each parallel worker. The login helpers in `tests/helpers/helpers.js` read this value and index directly into an array of four users per type, so worker N always uses its own dedicated user. When running serially or as a single test (no worker ID set), it falls back to worker 0.
+
+### Running tests
+
+Run the full suite (parallel, 4 workers):
 
 ```bash
-npm run test:local
+npm run test
 ```
 
-### Debugging local tests
+Run a single tagged scenario (useful for debugging):
 
 ```bash
-npm run test:local:debug
+npm run test -- --tags "@test36"
 ```
+
+Run a single feature file:
+
+```bash
+npm run clean && npx cucumber-js features/businessDetailsPermissions.feature
+```
+
+### Viewing reports
+
+The suite uses Allure for reporting. Generate and open a report from the results of the last run:
+
+```bash
+npm run report
+npx allure open allure-report
+```
+
+`npm run report:publish` generates the report and publishes it to S3 (used on CDP - locally the S3 step is skipped with a warning if `RESULTS_OUTPUT_S3_PATH` is not set).
 
 ## Production
 
-### Running the tests
-
-Tests are run from the CDP-Portal under the Test Suites section. Before any changes can be run, a new docker image must be built, this will happen automatically when a pull request is merged into the `main` branch.
-You can check the progress of the build under the actions section of this repository. Builds typically take around 1-2 minutes.
+Tests are run from the CDP Portal under the Test Suites section. Before changes can run, a new Docker image must be built. This happens automatically when a pull request is merged into `main`. You can check build progress under the Actions section of this repository — builds typically take 1-2 minutes.
 
 The results of the test run are made available in the portal.
 
-## Requirements of CDP Environment Tests
+### Requirements of CDP Environment Tests
 
-1. Your service builds as a docker container using the `.github/workflows/publish.yml`
-   The workflow tags the docker images allowing the CDP Portal to identify how the container should be run on the platform.
-   It also ensures its published to the correct docker repository.
+1. The service builds as a Docker container using `.github/workflows/publish.yml`. The workflow tags the Docker images so the CDP Portal can identify how the container should be run, and ensures it is published to the correct Docker repository.
 
-2. The Dockerfile's entrypoint script should return exit code of 0 if the test suite passes or 1/>0 if it fails
+2. The Dockerfile's entrypoint script should return exit code 0 if the suite passes, or a non-zero code if it fails.
 
-3. Test reports should be published to S3 using the script in `./bin/publish-tests.sh`
+3. Test reports are published to S3 using `./bin/publish-tests.sh`.
 
-## Running on GitHub
-
-Alternatively you can run the test suite as a GitHub workflow.
-Test runs on GitHub are not able to connect to the CDP Test environments. Instead, they run the tests agains a version of the services running in docker.
-A docker compose `compose.yml` is included as a starting point, which includes the databases (mongodb, redis) and infrastructure (floci) pre-setup.
-
-Steps:
-
-1. Edit the compose.yml to include your services.
-2. Modify the scripts in docker/scripts to pre-populate the database, if required and create any floci resources.
-3. Test the setup locally with `docker compose up` and `npm run test:github`
-4. Set up the workflow trigger in `.github/workflows/journey-tests`.
-
-By default, the provided workflow will run when triggered manually from GitHub or when triggered by another workflow.
-
-If you want to use the repository exclusively for running docker composed based test suites consider displaying the publish.yml workflow.
+The environment the suite runs against is controlled by the `ENVIRONMENT` variable, which the base URL is derived from (`https://fcp-sfd-frontend.${ENVIRONMENT}.cdp-int.defra.cloud`). Defaults to `test`.
 
 ## BrowserStack
 
-Two wdio configuration files are provided to help run the tests using BrowserStack in both a GitHub workflow (`wdio.github.browserstack.conf.js`) and from the CDP Portal (`wdio.browserstack.conf.js`).
-They can be run from npm using the `npm run test:browserstack` (for running via portal) and `npm run test:github:browserstack` (from GitHib runner).
-See the CDP Documentation for more details.
+BrowserStack integration is in progress currently for cross-browser and cross-device runs. More information will be added once work is complete.
 
 ## Licence
 
@@ -110,8 +162,6 @@ The following attribution statement MUST be cited in your products and applicati
 
 ### About the licence
 
-The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable
-information providers in the public sector to license the use and re-use of their information under a common open
-licence.
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 
 It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.

--- a/features/updateBusinessDetails.feature
+++ b/features/updateBusinessDetails.feature
@@ -3,35 +3,35 @@ Feature: Update business details
   Background:
     Given I am on SignIn page and enter the credentials for "BusinessDetails"
 
-  @test1 @sfd175 @serial
+  @test1 @sfd175
   Scenario: Verify phone number gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
     And I update phone number
     Then Verfiy updated phone details on the ViewAndUpdateYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessPhoneNumbers" on the page ViewAndUpdateYourBusinessType
 
-  @test2 @sfd175 @serial
+  @test2 @sfd175
   Scenario: Verify email gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessEmailAddress" link on the BusinessDetails page
     And I update Email
     Then Verfiy Updated email details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessEmailAddress" on the page ViewAndUpdateYourBusinessType
 
-  @test3 @sfd174 @serial
+  @test3 @sfd174
   Scenario: Verify postal address gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessAddress" link on the BusinessDetails page
     And I update Business Address
     Then Verfiy Updated Business Address details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessAddress" on the page ViewAndUpdateYourBusinessType
 
-  @test4 @sfd174 @serial
+  @test4 @sfd174
   Scenario: Verify business name gets updated on ViewAndUpdateYourBusinessType page
     When I click the "BusinessName" link on the BusinessDetails page
     And I update Business Name
     Then Verfiy Updated Business Name details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessName" on the page ViewAndUpdateYourBusinessType
 
-  @test9 @sfd285 @serial
+  @test9 @sfd285
   Scenario: Verify business name gets updated again by clicking change link on CheckYourBusinessNameIsCorrectBeforeSubmitting page
     When I click the "BusinessName" link on the BusinessDetails page
     And I update Business Name and click the Change link in CheckYourBusinessNameIsCorrectBeforeSubmitting Page
@@ -39,7 +39,7 @@ Feature: Update business details
     Then Verfiy Updated Business Name details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessName" on the page ViewAndUpdateYourBusinessType
 
-  @test10 @sfd285 @serial
+  @test10 @sfd285
   Scenario: Verify postal address gets updated again by clicking change link on EnterYourBusinessAddress page
     When I click the "BusinessAddress" link on the BusinessDetails page
     And I update Business Address and click the Change link in CheckYourBusinessAddressIsCorrectBeforeSubmitting Page
@@ -47,7 +47,7 @@ Feature: Update business details
     Then Verfiy Updated Business Address details on the ChangeYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessAddress" on the page ViewAndUpdateYourBusinessType
 
-  @test11 @sfd287 @serial
+  @test11 @sfd287
   Scenario: Verify phone number gets updated again by clicking change link on CheckYourBusinessPhoneNumbersAreCorrectBeforeSubmitting page
     When I click the "BusinessPhoneNumbers" link on the BusinessDetails page
     And I update Business PhoneNumber and click the Change link in CheckYourBusinessPhoneNumbersAreCorrectBeforeSubmitting Page
@@ -55,7 +55,7 @@ Feature: Update business details
     Then Verfiy Updated Business PhoneNumber details on the ViewAndUpdateYourBusinessType page are been displayed correctly
     And Verify Success Updated message is displayed for "BusinessPhonenumbers" on the page ViewAndUpdateYourBusinessType
 
-  @test12 @sfd287 @serial
+  @test12 @sfd287
   Scenario: Verify business email address gets updated again by clicking change link on CheckYourBusinessEmailAddressIsCorrectBeforeSubmitting page
     When I click the "BusinessEmailAddress" link on the BusinessDetails page
     And I update Business EmailAddress and click the Change link in CheckYourBusinessEmailAddressIsCorrectBeforeSubmitting Page
@@ -92,7 +92,7 @@ Feature: Update business details
       | WhatIsYourBusinessEmailAddress  |
       | ChangeYourBusinessType          |
 
-  @test18 @sfd325 @serial
+  @test18 @sfd325
   Scenario Outline: Verify application displays relevant message when selecting Yes or No on AreYouSureYouWantToRemoveYourVATRegistrationNumber page
     When I add the VAT Number
     And I click "<Link>" link
@@ -104,7 +104,7 @@ Feature: Update business details
       | Yes                   | Remove |
       | No                    | Remove |
 
-  @test19 @sfd383 @serial
+  @test19 @sfd383
   Scenario Outline: Verify updated VAT number is displayed on ViewAndUpdateYourBusinessType page
     When I add the VAT Number
     And I click "<Link>" link
@@ -180,7 +180,7 @@ Feature: Update business details
       | Change | VATnumber |          | Enter a VAT registration number                 | WhatIsYourVATRegistrationNumber |
       | Change | VATnumber |       10 | Enter a VAT registration number, like 123456789 | WhatIsYourVATRegistrationNumber |
 
-  @test45 @sfd2-809 @serial
+  @test45 @sfd2-809
   Scenario: Verify  Application is displaying relevant message whilist selecting Yes or No in AreYouSureYouWantToRemoveYourVATRegistrationNumber page
     When I add the VAT Number
     And I click "Remove" link
@@ -261,7 +261,7 @@ Feature: Update business details
       | Enter address manually | /business-address-enter  |
       | Change                 | /business-address-change |        
 
-  @test55 @sfd2-815 @serial
+  @test55 @sfd2-815
   Scenario: Verify business address can be updated using postcode lookup
     When I click the "BusinessAddress" link on the BusinessDetails page
     And I enter a valid postcode and continue to ChooseYourBusinessAddress page

--- a/features/updatePersonalDetails.feature
+++ b/features/updatePersonalDetails.feature
@@ -3,21 +3,21 @@ Feature: Update personal details
   Background:
     Given I am on SignIn page and enter the credentials for "PersonalDetails"
 
-  @test21 @sfd351 @serial
+  @test21 @sfd351
   Scenario: Verify personal phone number gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal phone number
     Then Verfiy updated phone details on the ViewAndUpdateYourPersonalDetails page are been displayed correctly
     And Verify Success Updated message is displayed for "PersonalPhoneNumbers" on the page ViewAndUpdateYourPersonalDetails page
 
-  @test22 @sfd347 @serial
+  @test22 @sfd347
   Scenario: Verify personal name gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "FullName" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal Name
     Then Verfiy Updated Personal Full Name details on the ViewAndUpdateYourPersonalDetails page are been displayed correctly
     And Verify Success Updated message is displayed for "FullName" on the page ViewAndUpdateYourPersonalDetails page
 
-  @test23 @sfd347 @serial
+  @test23 @sfd347
   Scenario: Verify personal name gets updated again by clicking change link on CheckYourNameIsCorrectBeforeSubmitting page
     When I click the "FullName" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal Name and click the Change link in CheckYourNameIsCorrectBeforeSubmitting page
@@ -25,7 +25,7 @@ Feature: Update personal details
     Then Verfiy Updated Personal Full Name details on the ViewAndUpdateYourPersonalDetails page are been displayed correctly
     And Verify Success Updated message is displayed for "FullName" on the page ViewAndUpdateYourPersonalDetails page
 
-  @test26 @sfd349 @serial
+  @test26 @sfd349
   Scenario Outline: Verify personal postal address gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "PersonalAddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I Update the Personal address "<AddressType>"
@@ -36,20 +36,20 @@ Feature: Update personal details
       | Manually       |
       | PostcodeLookup |
 
-  @test27 @sfd349 @serial
+  @test27 @sfd349
   Scenario: Verify personal postal address gets updated again by clicking change link on CheckYourPersonalAddressIsCorrectBeforeSubmitting page
     When I click the "PersonalAddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal Address Manually and click the Change link in CheckYourPersonalAddressIsCorrectBeforeSubmitting Page
     And Change the Personal Address Manually again in EnterYourPersonalAddress Page
     Then Verfiy updated Personal Address Manually changed details on the ViewAndUpdateYourPersonalDetails page are been displayed correctly
 
-  @test30 @sfd350 @serial
+  @test30 @sfd350
   Scenario: Verify personal date of birth gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "PersonalDOB" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update the dob
     And Verify Success Updated message is displayed for "DOB" on the page ViewAndUpdateYourPersonalDetails page
 
-  @test34 @sfd348 @serial
+  @test34 @sfd348
   Scenario: Verify personal email address gets updated on ViewAndUpdateYourPersonalDetails page
     When I click the "personalemailaddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal Email

--- a/features/viewPersonalDetails.feature
+++ b/features/viewPersonalDetails.feature
@@ -3,7 +3,7 @@ Feature: View personal details
   Background:
     Given I am on SignIn page and enter the credentials for "PersonalDetails"
 
-  @test25 @sfd386 @serial
+  @test25 @sfd386
   Scenario Outline: Verify previously entered phone details are retained when navigating back from CheckYourPersonalPhoneNumbersAreCorrectBeforeSubmitting page
     When I click the "PersonalPhoneNumbers" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal phone number and click the "<Link>" in the CheckYourPersonalPhoneNumbersAreCorrectBeforeSubmitting page
@@ -14,7 +14,7 @@ Feature: View personal details
       | change |
       | back   |
 
-  @test31 @sfd350 @serial
+  @test31 @sfd350
   Scenario Outline: Verify previously entered date of birth details are retained when navigating back from CheckYourDateOfBirthIsCorrectBeforeSubmitting page
     When I click the "PersonalDOB" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal DateOfBirth and click the "<Link>" in the CheckYourDateOfBirthIsCorrectBeforeSubmitting page
@@ -25,7 +25,7 @@ Feature: View personal details
       | change |
       | back   |
 
-  @test35 @sfd348 @serial
+  @test35 @sfd348
   Scenario Outline: Verify previously entered personal email address is retained when navigating back from CheckYourPersonalEmailAddressIsCorrectBeforeSubmitting page
     When I click the "personalemailaddress" link on the "ViewAndUpdateYourPersonalDetails"Page
     And I update Personal email address and click the "<Link>" in the CheckYourPersonalEmailAddressIsCorrectBeforeSubmitting page

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "clean": "rm -rf allure-results && rm -rf allure-report",
-    "test": "npm run clean && cucumber-js --tags 'not @serial' && cucumber-js --tags '@serial' --parallel 1",
+    "test": "npm run clean && cucumber-js",
     "test:smoke": "npm run clean && cucumber-js --tags '@smoke'",
     "test:tag": "npm run clean && cucumber-js --tags \"%TAG%\"",
     "test:cdp": "npm run clean && cucumber-js --config playwright.cdp.config.js",

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -3,6 +3,86 @@
 const ENVIRONMENT = process.env.ENVIRONMENT || 'test'
 export const TEST_SUITE_BASE_URL = `https://fcp-sfd-frontend.${ENVIRONMENT}.cdp-int.defra.cloud`
 
+// NEW: worker-specific standard user (0-3 maps to dedicated user)
+function getStandardUserCredentials() {
+  const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || '0')
+  const users = [
+    {
+      crn: process.env.USER_STANDARD_1_CRN,
+      password: process.env.USER_STANDARD_PASSWORD
+    },
+    {
+      crn: process.env.USER_STANDARD_2_CRN,
+      password: process.env.USER_STANDARD_PASSWORD
+    },
+    {
+      crn: process.env.USER_STANDARD_3_CRN,
+      password: process.env.USER_STANDARD_PASSWORD
+    },
+    {
+      crn: process.env.USER_STANDARD_4_CRN,
+      password: process.env.USER_STANDARD_PASSWORD
+    }
+  ]
+  return users[workerId] || users[0]
+}
+
+// NEW: worker-specific amend user
+function getAmendUserCredentials() {
+  const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || '0')
+  const users = [
+    {
+      crn: process.env.USER_AMEND_1_CRN,
+      password: process.env.USER_AMEND_PASSWORD,
+      sbi: process.env.USER_AMEND_1_SBI
+    },
+    {
+      crn: process.env.USER_AMEND_2_CRN,
+      password: process.env.USER_AMEND_PASSWORD,
+      sbi: process.env.USER_AMEND_2_SBI
+    },
+    {
+      crn: process.env.USER_AMEND_3_CRN,
+      password: process.env.USER_AMEND_PASSWORD,
+      sbi: process.env.USER_AMEND_3_SBI
+    },
+    {
+      crn: process.env.USER_AMEND_4_CRN,
+      password: process.env.USER_AMEND_PASSWORD,
+      sbi: process.env.USER_AMEND_4_SBI
+    }
+  ]
+  return users[workerId] || users[0]
+}
+
+// NEW: worker-specific view user
+function getViewUserCredentials() {
+  const workerId = parseInt(process.env.CUCUMBER_WORKER_ID || '0')
+  const users = [
+    {
+      crn: process.env.USER_VIEW_1_CRN,
+      password: process.env.USER_VIEW_PASSWORD,
+      sbi: process.env.USER_VIEW_1_SBI
+    },
+    {
+      crn: process.env.USER_VIEW_2_CRN,
+      password: process.env.USER_VIEW_PASSWORD,
+      sbi: process.env.USER_VIEW_2_SBI
+    },
+    {
+      crn: process.env.USER_VIEW_3_CRN,
+      password: process.env.USER_VIEW_PASSWORD,
+      sbi: process.env.USER_VIEW_3_SBI
+    },
+    {
+      crn: process.env.USER_VIEW_4_CRN,
+      password: process.env.USER_VIEW_PASSWORD,
+      sbi: process.env.USER_VIEW_4_SBI
+    }
+  ]
+  return users[workerId] || users[0]
+}
+
 export async function goToLandingPage(page) {
   await page.goto(`${TEST_SUITE_BASE_URL}/`)
   await page
@@ -12,40 +92,36 @@ export async function goToLandingPage(page) {
 }
 
 export async function loginAsStandardUser(page) {
+  // worker-specific user
+  const { crn, password } = getStandardUserCredentials()
   await goToLandingPage(page)
-  await page.locator("//input[@id='crn']").fill(process.env.USER_STANDARD_CRN)
-  await page
-    .locator("//input[@id='password']")
-    .fill(process.env.USER_STANDARD_PASSWORD)
+  await page.locator("//input[@id='crn']").fill(crn)
+  await page.locator("//input[@id='password']").fill(password)
   await page.locator("//button[@id='next']").click()
 }
 
 export async function loginAsAmendPermissionUser(page) {
+  // worker-specific user + SBI-based selection
+  const { crn, password, sbi } = getAmendUserCredentials()
   await goToLandingPage(page)
-  await page.locator("//input[@id='crn']").fill(process.env.USER_AMEND_CRN)
-  await page
-    .locator("//input[@id='password']")
-    .fill(process.env.USER_AMEND_PASSWORD)
+  await page.locator("//input[@id='crn']").fill(crn)
+  await page.locator("//input[@id='password']").fill(password)
   await page.locator("//button[@id='next']").click()
   await page
-    .locator(
-      `//label[contains(normalize-space(), "SBI ${process.env.USER_AMEND_SBI}")]`
-    )
+    .locator(`//label[contains(normalize-space(), "SBI ${sbi}")]`)
     .click()
   await page.locator("//button[@id='continueReplacement']").click()
 }
 
 export async function loginAsViewPermissionUser(page) {
+  // worker-specific user + SBI-based selection
+  const { crn, password, sbi } = getViewUserCredentials()
   await goToLandingPage(page)
-  await page.locator("//input[@id='crn']").fill(process.env.USER_VIEW_CRN)
-  await page
-    .locator("//input[@id='password']")
-    .fill(process.env.USER_VIEW_PASSWORD)
+  await page.locator("//input[@id='crn']").fill(crn)
+  await page.locator("//input[@id='password']").fill(password)
   await page.locator("//button[@id='next']").click()
   await page
-    .locator(
-      `//label[contains(normalize-space(), "SBI ${process.env.USER_VIEW_SBI}")]`
-    )
+    .locator(`//label[contains(normalize-space(), "SBI ${sbi}")]`)
     .click()
   await page.locator('#continueReplacement').click()
 }

--- a/tests/steps/testSteps.js
+++ b/tests/steps/testSteps.js
@@ -16,6 +16,7 @@ Given(
     switch (detailsType.toLowerCase()) {
       case 'businessdetails':
         await loginAsStandardUser(this.page)
+        await this.page.waitForLoadState('domcontentloaded')
         await this.page
           .locator(
             "//a[normalize-space()='View and update your business details']"
@@ -30,7 +31,7 @@ Given(
         break
       case 'personaldetails':
         await loginAsStandardUser(this.page)
-        await this.page.waitForLoadState('networkidle')
+        await this.page.waitForLoadState('domcontentloaded')
         await this.page
           .locator(
             "//a[normalize-space()='View and update your personal details']"
@@ -58,6 +59,7 @@ Given(
       case businessdetails === 'businessdetails' &&
         permission === 'amendpermission':
         await loginAsAmendPermissionUser(this.page)
+        await this.page.waitForLoadState('domcontentloaded')
         await this.page
           .locator(
             "//a[normalize-space()='View and update your business details']"
@@ -69,6 +71,7 @@ Given(
       case businessdetails === 'businessdetails' &&
         permission === 'viewpermission':
         await loginAsViewPermissionUser(this.page)
+        await this.page.waitForLoadState('domcontentloaded')
         await this.page
           .locator("//a[normalize-space()='View your Business details']")
           .click()
@@ -380,6 +383,7 @@ Then('Application should Navigate to mp06 Signed Out page.', async function () {
 Given('I sign In on the first tab', async function () {
   this.page1 = await this.context.newPage()
   await loginAsStandardUser(this.page1)
+  await this.page1.waitForLoadState('domcontentloaded')
   await this.page1
     .locator("//a[normalize-space()='View and update your business details']")
     .click()
@@ -1291,9 +1295,9 @@ Given(
   'I update Personal DateOfBirth and click the {string} in the CheckYourDateOfBirthIsCorrectBeforeSubmitting page',
   async function (linkType) {
     const dob = faker.date.birthdate({ min: 18, max: 90, mode: 'age' })
-    this.day = (dob.getDate() + 1).toString().padStart(2, '0')
-    this.month = (dob.getMonth() + 1).toString().padStart(2, '0')
-    this.year = (dob.getFullYear() + 1).toString()
+    this.day = String(dob.getUTCDate()).padStart(2, '0')
+    this.month = String(dob.getUTCMonth() + 1).padStart(2, '0')
+    this.year = String(dob.getUTCFullYear())
 
     await this.page.locator("//input[@id='day']").clear()
     await this.page.fill("//input[@id='day']", this.day)


### PR DESCRIPTION
## fix: resolve parallel execution failures with per-worker test users

### Description

Introduces dedicated test users per parallel worker to eliminate login session conflicts and data contention across the suite. Previously 3 users were shared across 4 workers running `parallel: 4`, causing login timeouts and unpredictable failures where one worker mutated data another was mid-assertion on. Mutating scenarios had been tagged `@serial` as a temporary workaround, forcing a two-pass run. This replaces that workaround with proper user isolation and restores a single clean parallel pass.

Closes [FLS2-164](https://eaflood.atlassian.net/browse/FLS2-164)

### Changes

- Added worker-specific credential helpers (`getStandardUserCredentials`, `getAmendUserCredentials`, `getViewUserCredentials`) using `CUCUMBER_WORKER_ID` to assign each of the 4 workers its own dedicated user
- Replaced hardcoded business selection labels with env var driven SBI selectors in the amend and view login flows
- Removed all `@serial` tags and reverted the test script to a single parallel pass
- Consolidated to a single shared password per user type to reduce env var overhead
- Added `waitForLoadState('domcontentloaded')` across all login paths to fix timing flake where the page was not ready when the details link locator fired after the B2C auth redirect
- Fixed invalid date generation in the Personal DateOfBirth step (removed `+1` on day and year which could produce invalid dates such as day 32, switched to UTC methods)
- Updated README with test user setup, required environment variables, and worker isolation docs

### How worker isolation works

`CUCUMBER_WORKER_ID` is set automatically by Cucumber-JS for each parallel worker (values 0 to 3 for `parallel: 4`). Each login helper reads this value and indexes directly into an array of four users per type, so worker N always uses its own dedicated user. When running serially or as a single test with no worker ID set, it falls back to worker 0.

### Verification

Worker isolation was confirmed by temporarily logging the CRN used by each worker across a full parallel run. Every worker consistently used its own dedicated CRN throughout, with no overlap between workers:

```
Worker 0 using standard CRN <CRN>
Worker 1 using standard CRN <CRN>
Worker 2 using standard CRN <CRN>
Worker 3 using standard CRN <CRN>
```

Test passing (3 consecutive test passes although I am seeing some flake every 4th or 5th run - to be investigated as a separate ticket)
<img width="661" height="815" alt="image" src="https://github.com/user-attachments/assets/cfd028ed-2de9-4d9f-a490-4c58fc8fad81" />


[FLS2-164]: https://eaflood.atlassian.net/browse/FLS2-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ